### PR TITLE
fix: force to use Http 1.1 to avoid HTTP2 GOAWAY error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea
 *.iws
 *.iml
 *.ipr

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBittorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBittorrent.java
@@ -42,6 +42,7 @@ public class QBittorrent implements Downloader {
         cm.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
         HttpClient.Builder builder = HttpClient
                 .newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
                 .followRedirects(HttpClient.Redirect.ALWAYS)
                 .connectTimeout(Duration.of(30, ChronoUnit.SECONDS))
                 .authenticator(new Authenticator() {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/ActiveProbing.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/ActiveProbing.java
@@ -153,6 +153,7 @@ public class ActiveProbing extends AbstractFeatureModule {
         cm.setCookiePolicy(CookiePolicy.ACCEPT_NONE);
         HttpClient.Builder builder = HttpClient
                 .newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
                 .followRedirects(HttpClient.Redirect.ALWAYS)
                 .connectTimeout(Duration.of(timeout, ChronoUnit.MILLIS))
                 .cookieHandler(cm);

--- a/src/main/java/cordelia/client/TrClient.java
+++ b/src/main/java/cordelia/client/TrClient.java
@@ -64,6 +64,7 @@ public final class TrClient {
         cm.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
         HttpClient.Builder builder = HttpClient
                 .newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
                 .followRedirects(HttpClient.Redirect.ALWAYS)
                 .connectTimeout(Duration.of(30, ChronoUnit.SECONDS))
                 .authenticator(new Authenticator() {


### PR DESCRIPTION
When using HTTP2, there is a chance of encountering a GOAWAY error, this pr disable the http2 to avoid this.
See also: https://github.com/OpenLiberty/open-liberty/issues/25279

```log
Caused by: java.io.IOException: /10.88.0.6:49612: GOAWAY received
	at java.net.http@22/jdk.internal.net.http.HttpClientImpl.send(HttpClientImpl.java:969)
	at java.net.http@22/jdk.internal.net.http.HttpClientFacade.send(HttpClientFacade.java:133)
	at com.ghostchu.peerbanhelper.downloader.impl.qbittorrent.QBittorrent.getPeers(QBittorrent.java:144)
	... 10 more
Caused by: java.io.IOException: /10.88.0.6:49612: GOAWAY received
	at java.net.http@22/jdk.internal.net.http.Http2Connection.handleGoAway(Http2Connection.java:1213)
	at java.net.http@22/jdk.internal.net.http.Http2Connection.handleConnectionFrame(Http2Connection.java:1027)
	at java.net.http@22/jdk.internal.net.http.Http2Connection.processFrame(Http2Connection.java:860)
	at java.net.http@22/jdk.internal.net.http.frame.FramesDecoder.decode(FramesDecoder.java:155)
	at java.net.http@22/jdk.internal.net.http.Http2Connection$FramesController.processReceivedData(Http2Connection.java:311)
	at java.net.http@22/jdk.internal.net.http.Http2Connection.asyncReceive(Http2Connection.java:782)
	at java.net.http@22/jdk.internal.net.http.Http2Connection$Http2TubeSubscriber.processQueue(Http2Connection.java:1604)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$LockingRestartableTask.run(SequentialScheduler.java:182)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(SequentialScheduler.java:149)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:207)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:280)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:233)
	at java.net.http@22/jdk.internal.net.http.Http2Connection$Http2TubeSubscriber.runOrSchedule(Http2Connection.java:1622)
	at java.net.http@22/jdk.internal.net.http.Http2Connection$Http2TubeSubscriber.onNext(Http2Connection.java:1648)
	at java.net.http@22/jdk.internal.net.http.Http2Connection$Http2TubeSubscriber.onNext(Http2Connection.java:1582)
	at java.net.http@22/jdk.internal.net.http.common.SSLTube$DelegateWrapper.onNext(SSLTube.java:210)
	at java.net.http@22/jdk.internal.net.http.common.SSLTube$SSLSubscriberWrapper.onNext(SSLTube.java:492)
	at java.net.http@22/jdk.internal.net.http.common.SSLTube$SSLSubscriberWrapper.onNext(SSLTube.java:295)
	at java.net.http@22/jdk.internal.net.http.common.SubscriberWrapper$DownstreamPusher.run1(SubscriberWrapper.java:316)
	at java.net.http@22/jdk.internal.net.http.common.SubscriberWrapper$DownstreamPusher.run(SubscriberWrapper.java:259)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$LockingRestartableTask.run(SequentialScheduler.java:182)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(SequentialScheduler.java:149)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:207)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:280)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:233)
	at java.net.http@22/jdk.internal.net.http.common.SubscriberWrapper.outgoing(SubscriberWrapper.java:232)
	at java.net.http@22/jdk.internal.net.http.common.SubscriberWrapper.outgoing(SubscriberWrapper.java:198)
	at java.net.http@22/jdk.internal.net.http.common.SSLFlowDelegate$Reader.processData(SSLFlowDelegate.java:465)
	at java.net.http@22/jdk.internal.net.http.common.SSLFlowDelegate$Reader$ReaderDownstreamPusher.run(SSLFlowDelegate.java:283)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$LockingRestartableTask.run(SequentialScheduler.java:182)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(SequentialScheduler.java:149)
	at java.net.http@22/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:207)
	at java.base@22/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@22/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base@22/java.lang.Thread.runWith(Thread.java:1583)
	at java.base@22/java.lang.Thread.run(Thread.java:1570)
	... 2 more

```