### PR TITLE
CI自动发布二进制文件

### DIFF
--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: graalvm/setup-graalvm@v1
       name: Setup GraalVM
       with:

--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: build-artifacts ${{ matrix.version }} on ${{ matrix.os }}
+        name: Linux-${{ github.sha }}
         path: |
           target/*.jar
           target/peerbanhelper-binary

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -24,7 +24,7 @@ jobs:
         version: [ latest ]
         os: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '22'
@@ -76,7 +76,7 @@ jobs:
         version: [ latest ]
         os: [ windows-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '22'

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -17,12 +17,8 @@ on:
       - published
 jobs:
   build-unix-like:
-    name: ${{ matrix.version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        version: [ latest ]
-        os: [ ubuntu-latest ]
+    name: build unix like
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
@@ -38,7 +34,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts ${{ matrix.version }} on ${{ matrix.os }}
+          name: Linux-${{ github.sha }}
           path: |
             target/PeerBanHelper.jar
             target/peerbanhelper-binary
@@ -69,12 +65,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-native-linux
   build-windows:
-    name: ${{ matrix.version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        version: [ latest ]
-        os: [ windows-latest ]
+    name: build windows
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
@@ -91,7 +83,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts ${{ matrix.version }} on ${{ matrix.os }}
+          name: Windows-${{ github.sha }}
           path: |
             target/PeerBanHelper.jar
             target/peerbanhelper-binary.exe

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -87,3 +87,36 @@ jobs:
           path: |
             target/PeerBanHelper.jar
             target/peerbanhelper-binary.exe
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build-unix-like,build-windows]
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Zip
+        working-directory: ./artifacts
+        run: |
+            for dir in ./*; do
+                  if [ -d $dir ]; then
+                        os="$(echo ${dir##*/} |cut -d- -f1)"
+                        zip -rj "PeerBanHelper.${{ github.event.release.tag_name }}.$os.zip" $dir/*
+                        rm -rf $dir
+                  fi
+            done
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/*.zip"
+          name: ${{ github.event.release.tag_name }}
+          omitNameDuringUpdate: true
+          tag: ${{ github.event.release.tag_name }}
+          allowUpdates: true
+          artifactErrorsFailBuild: true


### PR DESCRIPTION
* 发布release后自动打包zip、上传二进制可执行文件
* 修改了artifact名称
* 由于目前完全没必要用matrix，所以简化了
* 把基于Node.js 12/16的action更新版本，消除warning

已测试：https://github.com/zhongfly/PeerBanHelper/actions/runs/8674758135

未来计划：
* 把docker与build-unix-like分开，然后build-unix-like就可以与build-windows合并（可能并没有必要




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Simplified build configurations for better performance across different operating systems.
- **New Features**
    - Enhanced release automation to streamline the availability of new versions.
- **Chores**
    - Renamed job names and updated artifact upload names for Unix-like and Windows builds.
    - Added a new job for release automation that creates and uploads release artifacts in zipped format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->